### PR TITLE
Remove qps of routes that are not yet loaded from `qpCache`

### DIFF
--- a/addon/lazy-router.js
+++ b/addon/lazy-router.js
@@ -38,5 +38,17 @@ export default Ember.Router.extend({
       handler.routeName = name;
       return handler;
     };
+  },
+  _queryParamsFor: function(leafRouteName) {
+    var superQueryParams = this._super(...arguments);
+    var container = this.container;
+    var lazyLoaderService = container.lookup('service:lazy-loader');
+    var needsLazyLoading = !!lazyLoaderService.needsLazyLoading(leafRouteName);
+    //If the bundle is not yet loaded, the qps for the routes in the bundle will be stored as empty in `_qpCache`.
+    //Hence remove the qps of routes that are not yet loaded from `qpCache`
+    if (needsLazyLoading) {
+      delete this._qpCache[leafRouteName];
+    }
+    return superQueryParams;
   }
 });

--- a/tests/acceptance/lazy-router-test.js
+++ b/tests/acceptance/lazy-router-test.js
@@ -1,0 +1,20 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'dummy/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | lazy-router');
+
+test('Query params are not stored in cache for bundles that are not yet loaded', function(assert) {
+  visit('/');
+  andThen(()=>
+    visit('package1'));
+  andThen(()=>
+    visit('package1'));
+  andThen(()=>
+    visit('package2'));
+  andThen(()=>
+    visit('package1'));
+  andThen(()=>
+    visit('package2'));
+  andThen(() =>
+    assert.equal(find('.package2 a').attr('href'), '/package1?page=2&sort=DESC'));
+});

--- a/tests/dummy/packages/package1/controllers/package1.js
+++ b/tests/dummy/packages/package1/controllers/package1.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['sort', 'page'],
+  sort: 'ASC',
+  page: 1
+});

--- a/tests/dummy/packages/package2/templates/package2.hbs
+++ b/tests/dummy/packages/package2/templates/package2.hbs
@@ -1,3 +1,4 @@
 <div class="package2">
   Package 2
+  {{link-to 'Package 1' 'package1' (query-params sort='DESC' page=2)}}
 </div>


### PR DESCRIPTION
If a bundle is not yet loaded, the qps for the routes in the bundle will be stored as empty in `_qpCache`.  
Hence remove the qps of routes that are not yet loaded from `qpCache`