### PR TITLE
Lock loader version to 4.0.9 and fix a jshint error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,12 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1-13
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-1-13
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/addon/services/lazy-loader.js
+++ b/addon/services/lazy-loader.js
@@ -42,7 +42,7 @@ export default Ember.Service.extend({
       return Ember.RSVP.resolve();
     }
 
-    return this._loadAssets(bundle).then(()=>markBundleAsLoaded(bundle.name));
+    return this._loadAssets(bundle).then(()=>this.markBundleAsLoaded(bundle.name));
   },
 
   _getPackageRouter(packageName) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -17,39 +17,6 @@ module.exports = {
           'ember': '~1.13.0'
         }
       }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-sinon-qunit": "1.3.0",
     "ember-try": "^0.2.1",
     "jshint": "^2.9.1",
-    "loader.js": "^4.0.0",
+    "loader.js": "4.0.9",
     "mocha": "^2.4.5"
   },
   "keywords": [


### PR DESCRIPTION
Locks loader version to 4.9.0 so that tests pass.
Also fixes a jshint error in `services/lazy-loader.js`