### PR TITLE
Rearranging EmberApp param - `default` to make it as first param to `merge-defaults`

### DIFF
--- a/lib/broccoli/ember-app-with-packages.js
+++ b/lib/broccoli/ember-app-with-packages.js
@@ -71,7 +71,7 @@ function EmberAppWithPackages(defaults, options) {
         templates: new Funnel(appBuildConfig.appTreesBasePath + '/templates')
       }
     };
-    this.bootApp = new EmberApp(configWithTrees, defaults, sharedBuildConfig, appBuildConfig);
+    this.bootApp = new EmberApp(configWithTrees, sharedBuildConfig, appBuildConfig, defaults);
   }
 
   this.bootApp.contentFor = function(config, match, type) {


### PR DESCRIPTION
Making `defaults` as the first param to `merge-defaults` so that all other params of EmberApp will get included in `defaults` itself.
This makes all the integration test for components.