### PR TITLE
Passes all the bootApp.options to AssetRev, so consumers of this add-…

### DIFF
--- a/lib/broccoli/ember-app-with-packages.js
+++ b/lib/broccoli/ember-app-with-packages.js
@@ -166,6 +166,7 @@ EmberAppWithPackages.prototype.toTree = function (additionalTrees) {
     return new Funnel(packageTree);
   });
   var bootAppTree = this.bootApp.toTree();
+  var fingerPrintOptions = this.bootApp.options.fingerprint;
 
   var allTrees = mergeTrees(movedPackagesApplicationTrees.concat([bootAppTree/*, publicVendorFiles*/]).concat(additionalTrees || []), {
     overwrite: true,
@@ -173,7 +174,7 @@ EmberAppWithPackages.prototype.toTree = function (additionalTrees) {
   });
 
   if (env === 'production') {
-    allTrees = new AssetRev(allTrees);
+    allTrees = new AssetRev(allTrees, fingerPrintOptions);
   }
 
   return allTrees;


### PR DESCRIPTION
…on can configure fingerprinting in the same way they would configure any EmberApp