### PR TITLE
Avoid duplicate downloads

### DIFF
--- a/addon/services/lazy-loader.js
+++ b/addon/services/lazy-loader.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import bundles from 'ember-cli-bundle-loader/config/bundles';
 import { getContainer } from 'ember-cli-bundle-loader/utils/get-owner';
+import loadAssets from 'ember-cli-bundle-loader/utils/load-assets';
 
 const A = Ember.A;
 let loadedBundles = {};
@@ -50,7 +51,7 @@ export default Ember.Service.extend({
       return Ember.RSVP.resolve();
     }
 
-    return this._loadAssets(bundle).then(()=>this.markBundleAsLoaded(bundle.name));
+    return loadAssets(bundle.urls).then(()=>this.markBundleAsLoaded(bundle.name));
   },
 
   _getRouteNameFromUrl (url) {
@@ -59,38 +60,5 @@ export default Ember.Service.extend({
     if (routes && routes.length) {
       return routes[routes.length-1].handler;
     }
-  },
-
-  _loadAssets (bundle) {
-    const urls = bundle.urls || [];
-    const promises = urls.map(url=>
-      url.match(/\.js$/) ?
-        this._loadScript(url) :
-        url.match(/\.css$/) ?
-          this._loadStylesheet(url) :
-          Ember.RSVP.reject(`The specified url (${url}) for bundle ${bundle.name} doesnt match any of the expected types`)
-    );
-    return Ember.RSVP.all(promises);
-  },
-
-  // TODO: extract to a util.
-  _loadScript (url) {
-    var scriptElement = Ember.$("<script>").prop({src: url, async: true});
-    let promise = new Ember.RSVP.Promise((resolve, reject)=>{
-      scriptElement.one('load', ()=> Ember.run(null, resolve));
-      scriptElement.one('error', (evt)=> Ember.run(null, reject, evt));
-    });
-    document.head.appendChild(scriptElement[0]);
-    return promise;
-  },
-  // TODO: extract to a util.
-  _loadStylesheet (url) {
-    let linkElement = Ember.$(`<link rel="stylesheet" href="${url}" type="text/css"/>`);
-    let promise = new Ember.RSVP.Promise((resolve, reject)=>{
-      linkElement.one('load', ()=> Ember.run(null, resolve));
-      linkElement.one('error', (evt)=> Ember.run(null, reject, evt));
-    });
-    document.head.appendChild(linkElement[0]);
-    return promise;
   }
 });

--- a/addon/services/lazy-loader.js
+++ b/addon/services/lazy-loader.js
@@ -3,11 +3,15 @@ import bundles from 'ember-cli-bundle-loader/config/bundles';
 import { getContainer } from 'ember-cli-bundle-loader/utils/get-owner';
 import loadAssets from 'ember-cli-bundle-loader/utils/load-assets';
 
-const A = Ember.A;
+const {A, computed} = Ember;
 let loadedBundles = {};
 
 export default Ember.Service.extend({
   bundles: null,
+  loadedBundles: computed(function () {
+    return loadedBundles;
+  }),
+
   init () {
     this._super(...arguments);
     this.setBundles(bundles);

--- a/addon/services/lazy-loader.js
+++ b/addon/services/lazy-loader.js
@@ -32,14 +32,18 @@ export default Ember.Service.extend({
         routeName.match(pattern) && !A(bundle.blacklistedRouteNames||[]).find(blacklist=>
           routeName.match(blacklist))));
   },
+  getBundleByName (bundleName) {
+    return A(this.get('bundles')).find(bundle=> bundle.name === bundleName);
+  },
   loadBundleForUrl (url) {
     return this.loadBundleForRouteName(this._getRouteNameFromUrl(url));
   },
   loadBundleForRouteName (routeName) {
     return this.loadBundle(this.getBundleForRouteName(routeName));
   },
-  loadBundle (bundle) {
-    if (!bundle) {
+  loadBundle (bundleOrBundleName) {
+    const bundle = typeof bundleOrBundleName === 'string' ? this.getBundleByName(bundleOrBundleName) : bundleOrBundleName;
+    if (!bundleOrBundleName) {
       return Ember.RSVP.resolve();
     }
     if (this.isBundleLoaded(bundle.name)) {

--- a/addon/utils/load-assets.js
+++ b/addon/utils/load-assets.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+const {$, RSVP: {all}} = Ember;
+
+const inFlightPromises = {};
+export function singleInflightPromise(key, promiseGenerator) {
+  if (inFlightPromises[key]) {
+    // We already have a promise for that script, return it.
+    return inFlightPromises[key];
+  }
+  const promise = promiseGenerator();
+  inFlightPromises[key] = promise;
+  // When the promise is either resolved/rejected, we allow for another request
+  // NOTE: we only want to prevent inflight promises, but downloading the same
+  // asset more than once may be ok. lazyLoader.loadBundle already check that the
+  // bundle isn't loaded before attempting to loadAssets
+  promise.finally(()=> inFlightPromises[key] = undefined);
+  return promise;
+}
+
+export function loadScript (url) {
+  return singleInflightPromise(url, ()=> {
+    var scriptElement = $("<script>").prop({src: url, async: true});
+    let promise = new Ember.RSVP.Promise((resolve, reject)=>{
+      scriptElement.one('load', ()=> Ember.run(null, resolve));
+      scriptElement.one('error', (evt)=> Ember.run(null, reject, evt));
+    });
+    document.head.appendChild(scriptElement[0]);
+    return promise;
+  });
+}
+
+export function loadStylesheet (url) {
+  return singleInflightPromise(url, ()=>{
+    let linkElement = $(`<link rel="stylesheet" href="${url}" type="text/css"/>`);
+    let promise = new Ember.RSVP.Promise((resolve, reject)=>{
+      linkElement.one('load', ()=> Ember.run(null, resolve));
+      linkElement.one('error', (evt)=> Ember.run(null, reject, evt));
+    });
+    document.head.appendChild(linkElement[0]);
+    return promise;
+  });
+}
+
+export default function loadAssets(urls = []) {
+  urls = urls || [];
+  const promises = urls.map(url=>
+    url.match(/\.js$/) ?
+      loadScript(url) :
+      url.match(/\.css$/) ?
+        loadStylesheet(url) :
+        Ember.RSVP.reject(`The specified url (${url}) doesnt match any of the expected types`)
+  );
+  return all(promises);
+}

--- a/approvals/a_dev_build.contains_dummy_js.approved.txt
+++ b/approvals/a_dev_build.contains_dummy_js.approved.txt
@@ -653,10 +653,10 @@ catch(err) {
 /* jshint ignore:start */
 
 define('ember-cli-bundle-loader/config/bundles', function() { 
-  return [{"name":"package1","packages":["package1"],"urls":["assets/package1.js","assets/package1.css"],"routeNames":["^package1"]},{"name":"link-source","packages":["link-source"],"urls":["assets/link-source.js","assets/link-source.css"],"routeNames":["^link-source"]},{"name":"link-target","packages":["link-target"],"urls":["assets/link-target.js","assets/link-target.css"],"routeNames":["^link-target"]},{"name":"package2","packages":["package2"],"urls":["assets/package2.js","assets/package2.css"],"routeNames":["^package2"]},{"name":"slow","packages":["slow"],"urls":["assets/slow.js","assets/slow.css"],"routeNames":["^slow"]}]
+  return [{"name":"package1","packages":["package1"],"urls":["assets/package1.js","assets/package1.css"],"routeNames":["^package1"]},{"name":"link-source","packages":["link-source"],"urls":["assets/link-source.js","assets/link-source.css"],"routeNames":["^link-source"]},{"name":"link-target","packages":["link-target"],"urls":["assets/link-target.js","assets/link-target.css"],"routeNames":["^link-target"]},{"name":"load-assets-test","packages":["load-assets-test"],"urls":["assets/load-assets-test.js","assets/load-assets-test.css"],"routeNames":["^load-assets-test"]},{"name":"package2","packages":["package2"],"urls":["assets/package2.js","assets/package2.css"],"routeNames":["^package2"]},{"name":"slow","packages":["slow"],"urls":["assets/slow.js","assets/slow.css"],"routeNames":["^slow"]}]
 });
 define('ember-cli-bundle-loader/config/package-names', function() { 
-  return ["link-source","link-target","package1","package2","slow"]
+  return ["link-source","link-target","load-assets-test","package1","package2","slow"]
 });
 if (!runningTests) {
   require("dummy/app")["default"].create({});

--- a/approvals/a_dev_build.contains_vendor_js.approved.txt
+++ b/approvals/a_dev_build.contains_vendor_js.approved.txt
@@ -70015,10 +70015,16 @@ define('ember-cli-bundle-loader/services/lazy-loader', ['exports', 'ember', 'emb
   'use strict';
 
   var A = _ember['default'].A;
+  var computed = _ember['default'].computed;
+
   var loadedBundles = {};
 
   exports['default'] = _ember['default'].Service.extend({
     bundles: null,
+    loadedBundles: computed(function () {
+      return loadedBundles;
+    }),
+
     init: function init() {
       this._super.apply(this, arguments);
       this.setBundles(_emberCliBundleLoaderConfigBundles['default']);

--- a/approvals/a_dev_build.contains_vendor_js.approved.txt
+++ b/approvals/a_dev_build.contains_vendor_js.approved.txt
@@ -70011,7 +70011,7 @@ define('ember-cli-bundle-loader/routes/-lazy-loader', ['exports', 'ember'], func
     }
   });
 });
-define('ember-cli-bundle-loader/services/lazy-loader', ['exports', 'ember', 'ember-cli-bundle-loader/config/bundles', 'ember-cli-bundle-loader/utils/get-owner'], function (exports, _ember, _emberCliBundleLoaderConfigBundles, _emberCliBundleLoaderUtilsGetOwner) {
+define('ember-cli-bundle-loader/services/lazy-loader', ['exports', 'ember', 'ember-cli-bundle-loader/config/bundles', 'ember-cli-bundle-loader/utils/get-owner', 'ember-cli-bundle-loader/utils/load-assets'], function (exports, _ember, _emberCliBundleLoaderConfigBundles, _emberCliBundleLoaderUtilsGetOwner, _emberCliBundleLoaderUtilsLoadAssets) {
   'use strict';
 
   var A = _ember['default'].A;
@@ -70049,23 +70049,29 @@ define('ember-cli-bundle-loader/services/lazy-loader', ['exports', 'ember', 'emb
         });
       });
     },
+    getBundleByName: function getBundleByName(bundleName) {
+      return A(this.get('bundles')).find(function (bundle) {
+        return bundle.name === bundleName;
+      });
+    },
     loadBundleForUrl: function loadBundleForUrl(url) {
       return this.loadBundleForRouteName(this._getRouteNameFromUrl(url));
     },
     loadBundleForRouteName: function loadBundleForRouteName(routeName) {
       return this.loadBundle(this.getBundleForRouteName(routeName));
     },
-    loadBundle: function loadBundle(bundle) {
+    loadBundle: function loadBundle(bundleOrBundleName) {
       var _this = this;
 
-      if (!bundle) {
+      var bundle = typeof bundleOrBundleName === 'string' ? this.getBundleByName(bundleOrBundleName) : bundleOrBundleName;
+      if (!bundleOrBundleName) {
         return _ember['default'].RSVP.resolve();
       }
       if (this.isBundleLoaded(bundle.name)) {
         return _ember['default'].RSVP.resolve();
       }
 
-      return this._loadAssets(bundle).then(function () {
+      return (0, _emberCliBundleLoaderUtilsLoadAssets['default'])(bundle.urls).then(function () {
         return _this.markBundleAsLoaded(bundle.name);
       });
     },
@@ -70076,45 +70082,6 @@ define('ember-cli-bundle-loader/services/lazy-loader', ['exports', 'ember', 'emb
       if (routes && routes.length) {
         return routes[routes.length - 1].handler;
       }
-    },
-
-    _loadAssets: function _loadAssets(bundle) {
-      var _this2 = this;
-
-      var urls = bundle.urls || [];
-      var promises = urls.map(function (url) {
-        return url.match(/\.js$/) ? _this2._loadScript(url) : url.match(/\.css$/) ? _this2._loadStylesheet(url) : _ember['default'].RSVP.reject('The specified url (' + url + ') for bundle ' + bundle.name + ' doesnt match any of the expected types');
-      });
-      return _ember['default'].RSVP.all(promises);
-    },
-
-    // TODO: extract to a util.
-    _loadScript: function _loadScript(url) {
-      var scriptElement = _ember['default'].$("<script>").prop({ src: url, async: true });
-      var promise = new _ember['default'].RSVP.Promise(function (resolve, reject) {
-        scriptElement.one('load', function () {
-          return _ember['default'].run(null, resolve);
-        });
-        scriptElement.one('error', function (evt) {
-          return _ember['default'].run(null, reject, evt);
-        });
-      });
-      document.head.appendChild(scriptElement[0]);
-      return promise;
-    },
-    // TODO: extract to a util.
-    _loadStylesheet: function _loadStylesheet(url) {
-      var linkElement = _ember['default'].$('<link rel="stylesheet" href="' + url + '" type="text/css"/>');
-      var promise = new _ember['default'].RSVP.Promise(function (resolve, reject) {
-        linkElement.one('load', function () {
-          return _ember['default'].run(null, resolve);
-        });
-        linkElement.one('error', function (evt) {
-          return _ember['default'].run(null, reject, evt);
-        });
-      });
-      document.head.appendChild(linkElement[0]);
-      return promise;
     }
   });
 });
@@ -70148,6 +70115,78 @@ define("ember-cli-bundle-loader/utils/get-owner", ["exports", "ember"], function
     }
     var registry = container._registry || container.registry;
     registry.register(fullName, factory);
+  }
+});
+define('ember-cli-bundle-loader/utils/load-assets', ['exports', 'ember'], function (exports, _ember) {
+  'use strict';
+
+  exports.singleInflightPromise = singleInflightPromise;
+  exports.loadScript = loadScript;
+  exports.loadStylesheet = loadStylesheet;
+  exports['default'] = loadAssets;
+
+  var $ = _ember['default'].$;
+  var all = _ember['default'].RSVP.all;
+
+  var inFlightPromises = {};
+
+  function singleInflightPromise(key, promiseGenerator) {
+    if (inFlightPromises[key]) {
+      // We already have a promise for that script, return it.
+      return inFlightPromises[key];
+    }
+    var promise = promiseGenerator();
+    inFlightPromises[key] = promise;
+    // When the promise is either resolved/rejected, we allow for another request
+    // NOTE: we only want to prevent inflight promises, but downloading the same
+    // asset more than once may be ok. lazyLoader.loadBundle already check that the
+    // bundle isn't loaded before attempting to loadAssets
+    promise['finally'](function () {
+      return inFlightPromises[key] = undefined;
+    });
+    return promise;
+  }
+
+  function loadScript(url) {
+    return singleInflightPromise(url, function () {
+      var scriptElement = $("<script>").prop({ src: url, async: true });
+      var promise = new _ember['default'].RSVP.Promise(function (resolve, reject) {
+        scriptElement.one('load', function () {
+          return _ember['default'].run(null, resolve);
+        });
+        scriptElement.one('error', function (evt) {
+          return _ember['default'].run(null, reject, evt);
+        });
+      });
+      document.head.appendChild(scriptElement[0]);
+      return promise;
+    });
+  }
+
+  function loadStylesheet(url) {
+    return singleInflightPromise(url, function () {
+      var linkElement = $('<link rel="stylesheet" href="' + url + '" type="text/css"/>');
+      var promise = new _ember['default'].RSVP.Promise(function (resolve, reject) {
+        linkElement.one('load', function () {
+          return _ember['default'].run(null, resolve);
+        });
+        linkElement.one('error', function (evt) {
+          return _ember['default'].run(null, reject, evt);
+        });
+      });
+      document.head.appendChild(linkElement[0]);
+      return promise;
+    });
+  }
+
+  function loadAssets() {
+    var urls = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
+
+    urls = urls || [];
+    var promises = urls.map(function (url) {
+      return url.match(/\.js$/) ? loadScript(url) : url.match(/\.css$/) ? loadStylesheet(url) : _ember['default'].RSVP.reject('The specified url (' + url + ') doesnt match any of the expected types');
+    });
+    return all(promises);
   }
 });
 define("ember-get-config/index", ["exports"], function (exports) {

--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cli-bundle-loader'
+  name: 'ember-cli-bundle-loader',
+  // isDevelopingAddon: function () {
+  //   return true;
+  // }
 };

--- a/tests/acceptance/services/lazy-loader-test.js
+++ b/tests/acceptance/services/lazy-loader-test.js
@@ -59,11 +59,3 @@ test('_getRouteNamesFromUrl', function(assert) {
     assert.notOk(service._getRouteNameFromUrl('/doesntmatch'));
   });
 });
-
-test('_loadAssets throws if the bundle.urls dont have any of the valid extensions', function(assert) {
-  return getSubject()._loadAssets({name: 'my-bundle', urls: ['invalidextensions.exe']}).then(function() {
-    assert.ok(false, 'promise should not be fulfilled');
-  }).catch(function (error) {
-    assert.ok(error.match(/for bundle my-bundle/));
-  });
-});

--- a/tests/dummy/packages/load-assets-test/routes/load-assets-test.js
+++ b/tests/dummy/packages/load-assets-test/routes/load-assets-test.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend();

--- a/tests/dummy/packages/load-assets-test/styles/app.scss
+++ b/tests/dummy/packages/load-assets-test/styles/app.scss
@@ -1,0 +1,1 @@
+// This styles are loaded only with this package

--- a/tests/integration/components/my-component-test.js
+++ b/tests/integration/components/my-component-test.js
@@ -5,6 +5,8 @@ moduleForComponent('my-component', 'Integration | Component | my component', {
   integration: true
 });
 
+// This default test makes sure that the inline-precompile plugin for HBS
+// works with bundle-loader see issues#3
 test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });

--- a/tests/unit/utils/load-assets-test.js
+++ b/tests/unit/utils/load-assets-test.js
@@ -1,0 +1,45 @@
+import loadAssets, { singleInflightPromise } from 'ember-cli-bundle-loader/utils/load-assets';
+import { module, test } from 'qunit';
+import wait from 'ember-test-helpers/wait';
+import Ember from 'ember';
+
+module('Unit | Utility | load assets');
+
+test('singleInflightPromise returns the same promise on subsequent calls until the first one is settled', function(assert) {
+  assert.expect(3);
+
+  let resolve;
+  const promise = new Ember.RSVP.Promise(r=>resolve =r);
+  let returnedPromise = singleInflightPromise('test-key', ()=>promise);
+  assert.strictEqual(promise, returnedPromise);
+
+  returnedPromise = singleInflightPromise('test-key', ()=>new Ember.RSVP.Promise(()=>{}));
+  assert.strictEqual(promise, returnedPromise);
+
+  resolve(); // Settling the promise should result in a different promise being returned
+  return wait().then(() => {
+    returnedPromise = singleInflightPromise('test-key', ()=>new Ember.RSVP.Promise(()=>{}));
+    assert.notStrictEqual(promise, returnedPromise);
+  });
+});
+
+test('loadAssets doesn\'t add more than one script tag for inflight promises', function (assert) {
+  assert.equal(0, $('script[src="assets/load-assets-test.js"]').length);
+  assert.equal(0, $('link[href="assets/load-assets-test.css"]').length);
+  loadAssets(['assets/load-assets-test.js', 'assets/load-assets-test.css']);
+  loadAssets(['assets/load-assets-test.js', 'assets/load-assets-test.css']);
+  loadAssets(['assets/load-assets-test.js', 'assets/load-assets-test.css']);
+  loadAssets(['assets/load-assets-test.js', 'assets/load-assets-test.css']).finally(function() {
+    assert.equal(1, $('script[src="assets/load-assets-test.js"]').length);
+    assert.equal(1, $('link[href="assets/load-assets-test.css"]').length);
+  });
+  return wait();
+});
+
+test('loadAssets throws if the urls dont have any of the valid extensions', function(assert) {
+  return loadAssets(['invalidextensions.exe']).then(function() {
+    assert.ok(false, 'promise should not be fulfilled');
+  }).catch(function (error) {
+    assert.ok(error.match(/The specified url /));
+  });
+});


### PR DESCRIPTION
@zen-tmq

The idea here is to make sure that two different request for the same asset don't result in multiple request. 

When the promise is either resolved/rejected, we allow for another request
We only want to prevent inflight promises, but downloading the same
asset more than once may be ok. lazyLoader.loadBundle already checks that the
bundle isn't loaded before attempting to loadAssets, so the scenario here is for lazy-loading of vendor assets where two components might ask the lazyLoader service to load the asset around the same time (we issue a second request before the promise from the one promise settles).

I also pushed the documentation (see README.md) about how to lazy-load vendor libs from components.  