### PR TITLE
Adds support for ember 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/addon/lazy-router.js
+++ b/addon/lazy-router.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { get } = Ember;
+const { get, isArray } = Ember;
 import { getContainer, getFactory, registerFactory } from 'ember-cli-bundle-loader/utils/get-owner';
 
 export default Ember.Router.extend({
@@ -35,12 +35,18 @@ export default Ember.Router.extend({
         }
       }
 
-      handler.routeName = name;
+      if (typeof handler._setRouteName === 'function') {
+        handler._setRouteName(name);
+        handler._populateQPMeta();
+      } else {
+        handler.routeName = name;
+      }
       return handler;
     };
   },
 
-  _queryParamsFor: function(leafRouteName) {
+  _queryParamsFor: function(handlerInfosOrLeafRouteName) {
+    var leafRouteName = isArray(handlerInfosOrLeafRouteName) ? handlerInfosOrLeafRouteName[handlerInfosOrLeafRouteName.length - 1].name : handlerInfosOrLeafRouteName;
     var superQueryParams = this._super(...arguments);
     var container = getContainer(this);
     var lazyLoaderService = container.lookup('service:lazy-loader');

--- a/approvals/a_dev_build.contains_vendor_js.approved.txt
+++ b/approvals/a_dev_build.contains_vendor_js.approved.txt
@@ -69880,6 +69880,7 @@ define('ember-cli-bundle-loader/lazy-router', ['exports', 'ember', 'ember-cli-bu
   'use strict';
 
   var get = _ember['default'].get;
+  var isArray = _ember['default'].isArray;
   exports['default'] = _ember['default'].Router.extend({
     _getHandlerFunction: function _getHandlerFunction() {
       var container = (0, _emberCliBundleLoaderUtilsGetOwner.getContainer)(this);
@@ -69913,12 +69914,18 @@ define('ember-cli-bundle-loader/lazy-router', ['exports', 'ember', 'ember-cli-bu
           }
         }
 
-        handler.routeName = name;
+        if (typeof handler._setRouteName === 'function') {
+          handler._setRouteName(name);
+          handler._populateQPMeta();
+        } else {
+          handler.routeName = name;
+        }
         return handler;
       };
     },
 
-    _queryParamsFor: function _queryParamsFor(leafRouteName) {
+    _queryParamsFor: function _queryParamsFor(handlerInfosOrLeafRouteName) {
+      var leafRouteName = isArray(handlerInfosOrLeafRouteName) ? handlerInfosOrLeafRouteName[handlerInfosOrLeafRouteName.length - 1].name : handlerInfosOrLeafRouteName;
       var superQueryParams = this._super.apply(this, arguments);
       var container = (0, _emberCliBundleLoaderUtilsGetOwner.getContainer)(this);
       var lazyLoaderService = container.lookup('service:lazy-loader');


### PR DESCRIPTION
Changes has been made in [`_queryParamsFor`](https://github.com/emberjs/ember.js/commit/a14421bad1a623dfb27efaece35d14fb3f588efe) and [`_getHandlerFunction`](https://github.com/emberjs/ember.js/commit/ac957bcf9fc1eccc72a5af9bf81b519db379cda1) methods which breaks the addon.  
Made corresponding changes to make the addon compatible for ember 2.10.  

Still using bundler with engines is not supported. 
@MiguelMadero , can we support using bundler with engines so that the migration from bundler to engines can be done per packages?