### PR TITLE
Avoid errors if handler._populateQPMeta is missing

### DIFF
--- a/addon/lazy-router.js
+++ b/addon/lazy-router.js
@@ -37,7 +37,10 @@ export default Ember.Router.extend({
 
       if (typeof handler._setRouteName === 'function') {
         handler._setRouteName(name);
-        handler._populateQPMeta();
+        // handler._populateQPMeta function removed in Ember 2.13
+        if (handler._populateQPMeta) { 
+          handler._populateQPMeta();
+        }
       } else {
         handler.routeName = name;
       }


### PR DESCRIPTION
Upstream changes are removing the `_populateQPMeta` method on `Ember.Route` instances (in order to prevent the corresponding controller from being eagerly looked up).

This preserves the same semantics, but avoids invocation of `handler._populageQPMeta` if it is not present.

Related PRs:

* https://github.com/emberjs/ember.js/pull/14980
* https://github.com/ember-engines/ember-engines/pull/353